### PR TITLE
Show only current provider sessions

### DIFF
--- a/src/Pages/Authenticated/Dashboard/Dashboard.tsx
+++ b/src/Pages/Authenticated/Dashboard/Dashboard.tsx
@@ -14,7 +14,7 @@ import { useSnackbar } from 'notistack';
 import { ReactComponent as Logo } from '../../../assets/images/authenticated/pages/dashboard/logo.svg';
 import Header from '../../../Components/Header';
 import { RootState } from '../../../redux/store';
-import { fetchConfigAsync, fetchIdentityAsync } from '../../../redux/app.async.actions';
+import { fetchConfigAsync } from '../../../redux/app.async.actions';
 import { AppState } from '../../../redux/app.slice';
 import { SSEState } from '../../../redux/sse.slice';
 import SessionSidebar from '../SessionSidebar/SessionSidebar';
@@ -31,7 +31,6 @@ interface Props {
     app: AppState;
     sse: SSEState;
     actions: {
-        fetchIdentityAsync: () => void;
         fetchConfigAsync: () => void;
     };
 }
@@ -44,7 +43,6 @@ const mapStateToProps = (state: RootState) => ({
 const mapDispatchToProps = (dispatch: Dispatch<any>) => {
     return {
         actions: {
-            fetchIdentityAsync: () => dispatch(fetchIdentityAsync()),
             fetchConfigAsync: () => dispatch(fetchConfigAsync()),
         },
     };
@@ -72,9 +70,8 @@ const Dashboard = ({ actions, app, sse }: Props) => {
 
     const { enqueueSnackbar } = useSnackbar();
     useEffect(() => {
-        actions.fetchIdentityAsync();
         actions.fetchConfigAsync();
-    }, []);
+    });
 
     const { currentIdentity, config } = app;
     useEffect(() => {

--- a/src/Pages/Authenticated/SessionSidebar/SessionSidebar.tsx
+++ b/src/Pages/Authenticated/SessionSidebar/SessionSidebar.tsx
@@ -95,9 +95,7 @@ const SessionSidebar = ({
         }
     }, []);
 
-    const historyCards = (state.historySessions.length >= sessionsLimit ? state.historySessions : state.historySessions)
-        .slice(0, sessionsLimit - 1)
-        .map((hs) => toSessionCard(hs));
+    const historyCards = state.historySessions.map((hs) => toSessionCard(hs));
     const latestSessionCards = (liveSessions || []).map((ls) => toSessionCard(ls)).concat(historyCards);
 
     return (

--- a/src/Pages/Authenticated/SessionSidebar/SessionSidebar.tsx
+++ b/src/Pages/Authenticated/SessionSidebar/SessionSidebar.tsx
@@ -58,6 +58,7 @@ export interface Props {
     liveSessionStats?: SessionStats;
     displayNavigation?: boolean;
     liveSessionsOnly?: boolean;
+    sessionsLimit?: number;
     headerText: string;
 }
 
@@ -65,7 +66,7 @@ interface StateProps {
     historySessions: Session[];
 }
 
-const SessionSidebar = ({ liveSessions, liveSessionStats, displayNavigation, liveSessionsOnly, headerText }: Props) => {
+const SessionSidebar = ({ liveSessions, liveSessionStats, displayNavigation, liveSessionsOnly, sessionsLimit = 10, headerText }: Props) => {
     const [state, setState] = useState<StateProps>({ historySessions: [] });
 
     const { enqueueSnackbar } = useSnackbar();
@@ -73,7 +74,7 @@ const SessionSidebar = ({ liveSessions, liveSessionStats, displayNavigation, liv
     useEffect(() => {
         if (!liveSessionsOnly) {
             tequilapiClient
-                .sessions({ pageSize: 10 })
+                .sessions({ pageSize: sessionsLimit })
                 .then((resp) => setState({ ...state, historySessions: resp.items }))
                 .catch((err) => {
                     enqueueSnackbar(parseError(err) || 'Fetching Sessions Failed!');
@@ -82,8 +83,9 @@ const SessionSidebar = ({ liveSessions, liveSessionStats, displayNavigation, liv
         }
     }, []);
 
-    const historySessionCount = state.historySessions.length >= 10 ? 10 : state.historySessions.length;
-    const historyCards = state.historySessions.slice(0, historySessionCount - 1).map((hs) => toSessionCard(hs));
+    const historyCards = (state.historySessions.length >= sessionsLimit ? state.historySessions : state.historySessions)
+        .slice(0, sessionsLimit - 1)
+        .map((hs) => toSessionCard(hs));
     const latestSessionCards = (liveSessions || []).map((ls) => toSessionCard(ls)).concat(historyCards);
 
     return (

--- a/src/Pages/Authenticated/Sessions/Sessions.tsx
+++ b/src/Pages/Authenticated/Sessions/Sessions.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 import { Session, SessionDirection, SessionListResponse } from 'mysterium-vpn-js';
-import React, { FC, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useSnackbar } from 'notistack';
 
 import { tequilapiClient } from '../../../api/TequilApiClient';
@@ -68,7 +68,7 @@ const row = (s: Session): TableRow => {
     };
 };
 
-const Sessions: FC<Props> = ({ filterDirection = SessionDirection.PROVIDED, filterProviderId }: Props) => {
+const Sessions = ({ filterDirection = SessionDirection.PROVIDED, filterProviderId }: Props) => {
     const [state, setState] = useState<StateProps>({
         isLoading: true,
         pageSize: 10,

--- a/src/Pages/Authenticated/Sessions/Sessions.tsx
+++ b/src/Pages/Authenticated/Sessions/Sessions.tsx
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import { Session, SessionListResponse } from 'mysterium-vpn-js';
+import { Session, SessionDirection, SessionListResponse } from 'mysterium-vpn-js';
 import React, { FC, useEffect, useState } from 'react';
 import { useSnackbar } from 'notistack';
 
@@ -19,6 +19,17 @@ import Table, { TableRow } from '../../../Components/Table/Table';
 import SessionSidebar from '../SessionSidebar/SessionSidebar';
 import './Sessions.scss';
 import { parseError } from '../../../commons/error.utils';
+import { RootState } from '../../../redux/store';
+import { connect } from 'react-redux';
+
+export interface Props {
+    filterDirection?: SessionDirection;
+    filterProviderId?: string;
+}
+
+const mapStateToProps = (state: RootState) => ({
+    filterProviderId: state.app.currentIdentity?.id,
+});
 
 interface StateProps {
     isLoading: boolean;
@@ -57,7 +68,7 @@ const row = (s: Session): TableRow => {
     };
 };
 
-const Sessions: FC = () => {
+const Sessions: FC<Props> = ({ filterDirection = SessionDirection.PROVIDED, filterProviderId }: Props) => {
     const [state, setState] = useState<StateProps>({
         isLoading: true,
         pageSize: 10,
@@ -67,7 +78,12 @@ const Sessions: FC = () => {
     const { enqueueSnackbar } = useSnackbar();
     useEffect(() => {
         tequilapiClient
-            .sessions({ pageSize: state.pageSize, page: state.currentPage })
+            .sessions({
+                direction: filterDirection,
+                providerId: filterProviderId,
+                pageSize: state.pageSize,
+                page: state.currentPage,
+            })
             .then((resp) => {
                 setState({ ...state, isLoading: false, sessionListResponse: resp });
             })
@@ -121,4 +137,4 @@ const Sessions: FC = () => {
     );
 };
 
-export default Sessions;
+export default connect(mapStateToProps)(Sessions);


### PR DESCRIPTION
This fixes:
- Remove session&stats about consumer sessions (if any)
- Show only sessions of currently loaded identity 