### PR TITLE
Pass thru Onboarding when unregistered identity found

### DIFF
--- a/src/Pages/AppRouter.tsx
+++ b/src/Pages/AppRouter.tsx
@@ -96,10 +96,11 @@ const mapDispatchToProps = (dispatch: Dispatch<any>) => {
 };
 
 const redirectTo = (needsOnboarding: boolean, loggedIn: boolean): JSX.Element => {
+    if (!loggedIn) {
+        return <Redirect to={LOGIN} />;
+    }
     if (needsOnboarding) {
         return <Redirect to={ONBOARDING_HOME} />;
-    } else if (!loggedIn) {
-        return <Redirect to={LOGIN} />;
     }
 
     return <Redirect to={DASHBOARD} />;

--- a/src/Pages/AppRouter.tsx
+++ b/src/Pages/AppRouter.tsx
@@ -14,7 +14,14 @@ import { connect } from 'react-redux';
 import '../assets/styles/App.scss';
 import { sseAppStateStateChanged, SSEState } from '../redux/sse.slice';
 import ConnectToSSE from '../sse/server-sent-events';
-import { Auth, isLoggedIn, needsPasswordChange, shouldBeOnboarded, termsAccepted } from '../redux/app.slice';
+import {
+    Auth,
+    isLoggedIn,
+    needsPasswordChange,
+    needsRegisteredIdentity,
+    termsAccepted,
+    shouldBeOnboarded,
+} from '../redux/app.slice';
 import { fetchConfigAsync, fetchFeesAsync, updateTermsStoreAsync } from '../redux/app.async.actions';
 import { updateAuthenticatedStore, updateAuthFlowLoadingStore } from '../redux/app.slice';
 import { RootState } from '../redux/store';
@@ -46,6 +53,7 @@ interface Props {
     loggedIn: boolean;
     termsAccepted: boolean;
     needsPasswordChange: boolean;
+    needsRegisteredIdentity: boolean;
     needsOnboarding: boolean;
     fees?: Fees;
     sse?: SSEState;
@@ -67,6 +75,7 @@ const mapStateToProps = (state: RootState) => ({
     loggedIn: isLoggedIn(state.app),
     termsAccepted: termsAccepted(state.app),
     needsPasswordChange: needsPasswordChange(state.app),
+    needsRegisteredIdentity: needsRegisteredIdentity(state.app),
     needsOnboarding: shouldBeOnboarded(state.app),
     fees: state.app.fees,
     sse: state.sse,
@@ -103,6 +112,7 @@ const AppRouter = ({
     loggedIn,
     needsOnboarding,
     needsPasswordChange,
+    needsRegisteredIdentity,
     termsAccepted,
     fees,
     actions,
@@ -179,8 +189,9 @@ const AppRouter = ({
                             config={config}
                             fees={fees}
                             identity={identity}
-                            termsAccepted={termsAccepted}
                             needsPasswordChange={needsPasswordChange}
+                            needsRegisteredIdentity={needsRegisteredIdentity}
+                            termsAccepted={termsAccepted}
                         />
                     ) : (
                         <Redirect to={DASHBOARD} />

--- a/src/Pages/Onboarding/OnboardingPage.tsx
+++ b/src/Pages/Onboarding/OnboardingPage.tsx
@@ -8,7 +8,6 @@
 import React, { useState } from 'react';
 import { Fees, Identity } from 'mysterium-vpn-js';
 import { CircularProgress } from '@material-ui/core';
-import { isUnregistered } from '../../commons/isIdentity.utils';
 
 import sideImage from '../../assets/images/onboarding/SideImage.png';
 
@@ -26,6 +25,7 @@ interface Props {
     termsAccepted: boolean;
     identity?: Identity;
     needsPasswordChange: boolean;
+    needsRegisteredIdentity: boolean;
     config?: Config;
     fees?: Fees;
 }
@@ -35,7 +35,14 @@ export interface SettlementProps {
     beneficiary: string;
 }
 
-const OnboardingPage = ({ needsPasswordChange, termsAccepted, identity, config, fees }: Props) => {
+const OnboardingPage = ({
+    needsPasswordChange,
+    needsRegisteredIdentity,
+    termsAccepted,
+    identity,
+    config,
+    fees,
+}: Props) => {
     const [currentStep, setCurrentStep] = useState(0);
 
     const callbacks: OnboardingChildProps = {
@@ -54,7 +61,7 @@ const OnboardingPage = ({ needsPasswordChange, termsAccepted, identity, config, 
         steps.push(<TermsAndConditions key="terms" callbacks={callbacks} />);
     }
 
-    if (isUnregistered(identity)) {
+    if (needsRegisteredIdentity) {
         steps.push(<PriceSettings config={config} key="price" callbacks={callbacks} />);
         steps.push(<SettlementSettings key="payout" identity={identity} callbacks={callbacks} fees={fees} />);
     }

--- a/src/redux/app.slice.ts
+++ b/src/redux/app.slice.ts
@@ -9,6 +9,7 @@ import { Config } from 'mysterium-vpn-js/lib/config/config';
 import { createSlice } from '@reduxjs/toolkit';
 
 import { areTermsAccepted } from '../commons/terms';
+import { isUnregistered } from '../commons/isIdentity.utils';
 
 export interface Auth {
     authenticated?: boolean;
@@ -74,6 +75,10 @@ const needsPasswordChange = (state: AppState): boolean => {
     return !!state.auth.withDefaultCredentials;
 };
 
+const needsRegisteredIdentity = (state: AppState): boolean => {
+    return !state.currentIdentity || isUnregistered(state.currentIdentity);
+};
+
 const termsAccepted = (state: AppState): boolean => {
     return areTermsAccepted(state.terms.acceptedAt, state.terms.acceptedVersion);
 };
@@ -81,10 +86,10 @@ const termsAccepted = (state: AppState): boolean => {
 const shouldBeOnboarded = (state: AppState): boolean => {
     // TODO if !needsPasswordChange(state) then infinite loading
     // return !termsAccepted(state) || needsPasswordChange(state)
-    return needsPasswordChange(state);
+    return needsPasswordChange(state) || needsRegisteredIdentity(state);
 };
 
-export { isLoggedIn, needsPasswordChange, termsAccepted, shouldBeOnboarded };
+export { isLoggedIn, needsPasswordChange, needsRegisteredIdentity, termsAccepted, shouldBeOnboarded };
 
 export const {
     updateAuthenticatedStore,


### PR DESCRIPTION
Was not able to test identity:
```
» identities get 0x0c8984953ae49b5d3f973c6113944b2acf559239
[INFO] Registration clio.Status: Unregistered
[INFO] Channel address: 0x7753FA326122Ae1dc9a5C6e2945845E6c89a3ff7
[INFO] Balance: 0.000000MYST
[INFO] Earnings: 0.000000MYST
[INFO] Earnings total: 0.000000MYST
```