### PR TITLE
Onboarding subscribes current identity details from SSE

### DIFF
--- a/src/Pages/AppRouter.tsx
+++ b/src/Pages/AppRouter.tsx
@@ -58,15 +58,18 @@ interface Props {
     };
 }
 
-const mapStateToProps = (state: RootState) => ({
-    config: state.app.config,
-    loading: state.app.loading,
-    loggedIn: isLoggedIn(state.app.auth),
-    identity: currentIdentity(state.app.currentIdentityRef, state.sse.appState?.identities),
-    onboarding: onboardingState(state.app.auth, state.app.terms, state.app.currentIdentity),
-    fees: state.app.fees,
-    sse: state.sse,
-});
+const mapStateToProps = (state: RootState) => {
+    const identity = currentIdentity(state.app.currentIdentityRef, state.sse.appState?.identities);
+    return {
+        config: state.app.config,
+        loading: state.app.loading,
+        loggedIn: isLoggedIn(state.app.auth),
+        identity: identity,
+        onboarding: onboardingState(state.app.auth, state.app.terms, identity),
+        fees: state.app.fees,
+        sse: state.sse,
+    };
+};
 
 const mapDispatchToProps = (dispatch: Dispatch<any>) => {
     return {

--- a/src/Pages/AppRouter.tsx
+++ b/src/Pages/AppRouter.tsx
@@ -17,6 +17,7 @@ import ConnectToSSE from '../sse/server-sent-events';
 import {
     Auth,
     isLoggedIn,
+    currentIdentity,
     needsPasswordChange,
     needsRegisteredIdentity,
     termsAccepted,
@@ -71,7 +72,7 @@ interface Props {
 const mapStateToProps = (state: RootState) => ({
     config: state.app.config,
     loading: state.app.loading,
-    identity: state.app.currentIdentity,
+    identity: currentIdentity(state.app.currentIdentityRef, state.sse.appState?.identities),
     loggedIn: isLoggedIn(state.app),
     termsAccepted: termsAccepted(state.app),
     needsPasswordChange: needsPasswordChange(state.app),

--- a/src/Pages/Login/LoginPage.tsx
+++ b/src/Pages/Login/LoginPage.tsx
@@ -15,7 +15,7 @@ import '../../assets/styles/pages/login/main.scss';
 import { DefaultTextField } from '../../Components/DefaultTextField';
 import { DEFAULT_USERNAME } from '../../constants/defaults';
 import Button from '../../Components/Buttons/Button';
-import { loginAndStoreCurrentIdentity } from '../../api/TequilAPIWrapper';
+import { login } from '../../api/TequilAPIWrapper';
 
 interface Props {
     onSuccessLogin: () => void;
@@ -41,7 +41,7 @@ const LoginPage = ({ onSuccessLogin }: Props) => {
     const handleLogin = (e: FormEvent<any>) => {
         e.preventDefault();
         setState({ ...state, error: false, isLoading: true });
-        loginAndStoreCurrentIdentity(DEFAULT_USERNAME, state.password)
+        login(DEFAULT_USERNAME, state.password)
             .then(() =>
                 store.dispatch(updateAuthenticatedStore({ authenticated: true, withDefaultCredentials: false })),
             )

--- a/src/Pages/Onboarding/OnboardingPage.tsx
+++ b/src/Pages/Onboarding/OnboardingPage.tsx
@@ -19,13 +19,12 @@ import PriceSettings from './steps/PriceSettings';
 import SettlementSettings from './steps/SettlementSettings';
 
 import './Onboarding.scss';
+import { Onboarding } from '../../redux/app.slice';
 import { Config } from 'mysterium-vpn-js/lib/config/config';
 
 interface Props {
-    termsAccepted: boolean;
+    onboarding: Onboarding;
     identity?: Identity;
-    needsPasswordChange: boolean;
-    needsRegisteredIdentity: boolean;
     config?: Config;
     fees?: Fees;
 }
@@ -35,14 +34,7 @@ export interface SettlementProps {
     beneficiary: string;
 }
 
-const OnboardingPage = ({
-    needsPasswordChange,
-    needsRegisteredIdentity,
-    termsAccepted,
-    identity,
-    config,
-    fees,
-}: Props) => {
+const OnboardingPage = ({ onboarding, identity, config, fees }: Props) => {
     const [currentStep, setCurrentStep] = useState(0);
 
     const callbacks: OnboardingChildProps = {
@@ -57,16 +49,16 @@ const OnboardingPage = ({
 
     const steps = [<Welcome key="welcome" callbacks={callbacks} />];
 
-    if (!termsAccepted) {
+    if (!onboarding.termsAccepted) {
         steps.push(<TermsAndConditions key="terms" callbacks={callbacks} />);
     }
 
-    if (needsRegisteredIdentity) {
+    if (onboarding.needsRegisteredIdentity) {
         steps.push(<PriceSettings config={config} key="price" callbacks={callbacks} />);
         steps.push(<SettlementSettings key="payout" identity={identity} callbacks={callbacks} fees={fees} />);
     }
 
-    if (needsPasswordChange) {
+    if (onboarding.needsPasswordChange) {
         steps.push(<PasswordChange key="password" config={config} callbacks={callbacks} />);
     }
 

--- a/src/api/TequilAPIWrapper.ts
+++ b/src/api/TequilAPIWrapper.ts
@@ -10,20 +10,13 @@ import { Config } from 'mysterium-vpn-js/lib/config/config';
 
 import { ServiceType } from '../commons';
 import { store } from '../redux/store';
-import { DEFAULT_IDENTITY_PASSPHRASE, DEFAULT_PASSWORD, DEFAULT_USERNAME } from '../constants/defaults';
-import { updateConfigStore, updateIdentityStore } from '../redux/app.slice';
+import { DEFAULT_PASSWORD, DEFAULT_USERNAME } from '../constants/defaults';
+import { updateConfigStore } from '../redux/app.slice';
 
 import { tequilapiClient } from './TequilApiClient';
 
-export const loginAndStoreCurrentIdentity = async (username: string, password: string): Promise<void> => {
-    return await tequilapiClient
-        .authLogin({ username, password })
-        .then(() => tequilapiClient.identityCurrent({ passphrase: DEFAULT_IDENTITY_PASSPHRASE }))
-        .then((identityRef) => tequilapiClient.identity(identityRef.id))
-        .then((identity) => {
-            store.dispatch(updateIdentityStore(identity));
-            return Promise.resolve();
-        });
+export const login = async (username: string, password: string): Promise<void> => {
+    return await tequilapiClient.authLogin({ username, password }).then(() => Promise.resolve());
 };
 
 export const loginWithDefaultCredentials = async (): Promise<boolean> => {

--- a/src/redux/app.slice.ts
+++ b/src/redux/app.slice.ts
@@ -4,12 +4,13 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import { Fees, Identity } from 'mysterium-vpn-js';
+import { Fees, IdentityRef, Identity } from 'mysterium-vpn-js';
 import { Config } from 'mysterium-vpn-js/lib/config/config';
 import { createSlice } from '@reduxjs/toolkit';
 
 import { areTermsAccepted } from '../commons/terms';
 import { isUnregistered } from '../commons/isIdentity.utils';
+import _ from 'lodash';
 
 export interface Auth {
     authenticated?: boolean;
@@ -23,6 +24,7 @@ export interface Terms {
 
 export interface AppState {
     loading: boolean;
+    currentIdentityRef?: IdentityRef;
     currentIdentity?: Identity;
     auth: Auth;
     terms: Terms;
@@ -67,6 +69,12 @@ const slice = createSlice({
     },
 });
 
+// Hot identity details (from SSE).
+const currentIdentity = (identityRef?: IdentityRef, identities?: Identity[]) => {
+    const result = (identities || []).filter((si) => si.id === identityRef?.id);
+    return _.head(result);
+};
+
 const isLoggedIn = (state: AppState): boolean => {
     return !!state.auth.authenticated;
 };
@@ -89,7 +97,7 @@ const shouldBeOnboarded = (state: AppState): boolean => {
     return needsPasswordChange(state) || needsRegisteredIdentity(state);
 };
 
-export { isLoggedIn, needsPasswordChange, needsRegisteredIdentity, termsAccepted, shouldBeOnboarded };
+export { isLoggedIn, currentIdentity, needsPasswordChange, needsRegisteredIdentity, termsAccepted, shouldBeOnboarded };
 
 export const {
     updateAuthenticatedStore,


### PR DESCRIPTION
Avoid having current identity details cached in state at all. Because it's being from Tequilapi just on page load.

Fixes: When identity.registrationStatus changes we still show Onboarding page.