### PR TITLE
Tweaks & Fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dvpn-web",
   "productName": "Mysterium WebUI",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Mysterium WebUI is a web application for accessing Mysterium Network - decentralized VPN built on blockchain.",
   "license": "MIT",
   "repository": {

--- a/src/Pages/AppRouter.tsx
+++ b/src/Pages/AppRouter.tsx
@@ -110,6 +110,7 @@ const AppRouter = ({ config, loading, identity, loggedIn, onboarding, fees, acti
 
   useLayoutEffect(() => {
     const blockingCheck = async () => {
+      await loginWithDefaultCredentials()
       const authenticated = await isUserAuthenticated()
 
       if (authenticated) {

--- a/src/Pages/Authenticated/Dashboard/Bounty/BountyWidget.tsx
+++ b/src/Pages/Authenticated/Dashboard/Bounty/BountyWidget.tsx
@@ -11,8 +11,11 @@ import { tequilapiClient } from '../../../../api/TequilApiClient'
 import { MMNReport, MMNReportResponse } from 'mysterium-vpn-js'
 import { CircularProgress } from '@material-ui/core'
 import './BountyWidget.scss'
+import { useSnackbar } from 'notistack'
+import { parseError, parseMMNError } from '../../../../commons/error.utils'
 
 const BountyWidget = ({ mmnUrl }: { mmnUrl: string }) => {
+  const { enqueueSnackbar } = useSnackbar()
   const [isLoading, setIsLoading] = useState(true)
   const [bountyReport, setBountyReport] = useState<MMNReport>({} as MMNReport)
   const [nodeInfo, setNodeInfo] = useState<MMNReportResponse>({} as MMNReportResponse)
@@ -26,6 +29,7 @@ const BountyWidget = ({ mmnUrl }: { mmnUrl: string }) => {
         setBountyReport(response.report as MMNReport)
       })
       .catch((e) => {
+        enqueueSnackbar(parseError(e) || parseMMNError(e), { variant: 'error' })
         console.log(e)
       })
       .finally(() => {

--- a/src/Pages/Authenticated/Dashboard/Dashboard.tsx
+++ b/src/Pages/Authenticated/Dashboard/Dashboard.tsx
@@ -10,7 +10,7 @@ import { CircularProgress } from '@material-ui/core'
 import { connect } from 'react-redux'
 import { Session, SessionDirection, SessionStats, SessionStatus } from 'mysterium-vpn-js'
 import { useSnackbar } from 'notistack'
-import { mmnWebAddress } from '../../../commons/config'
+import { isTestnet, mmnWebAddress } from '../../../commons/config'
 
 import { ReactComponent as Logo } from '../../../assets/images/authenticated/pages/dashboard/logo.svg'
 import Header from '../../../Components/Header'
@@ -103,13 +103,14 @@ const Dashboard = ({ app, sse }: Props) => {
 
   const serviceInfos = appState.serviceInfo
   const { status } = appState.natStatus
+  const testnet = isTestnet(config)
 
   return (
     <div className="main">
       <div className="main-block main-block--split">
         <Header logo={Logo} name="Dashboard" />
         <div className="dashboard__statistics">
-          <Statistics stats={state.sessionStatsAllTime} unsettledEarnings={identity.earnings} />
+          <Statistics testnet={testnet} stats={state.sessionStatsAllTime} unsettledEarnings={identity.earnings} />
         </div>
         <div className="dashboard__widgets">
           <div className="widget widget--bounty">

--- a/src/Pages/Authenticated/Dashboard/Statistics/Statistics.tsx
+++ b/src/Pages/Authenticated/Dashboard/Statistics/Statistics.tsx
@@ -16,12 +16,17 @@ import Statistic from './Statistic'
 interface Props {
   stats: SessionStats
   unsettledEarnings: number
+  testnet?: boolean
 }
 
-const Statistics = ({ stats, unsettledEarnings }: Props) => {
+const Statistics = ({ stats, unsettledEarnings, testnet }: Props) => {
   return (
     <>
-      <Statistic stat={displayMyst(unsettledEarnings)} name="Unsettled earnings" />
+      {testnet ? (
+        <Statistic stat={displayMyst(stats.sumTokens)} name="Total Earnings" />
+      ) : (
+        <Statistic stat={displayMyst(unsettledEarnings)} name="Unsettled earnings" />
+      )}
       <Statistic stat={seconds2ISOTime(stats.sumDuration)} name="Sessions time" />
       <Statistic stat={formatBytes(add(stats.sumBytesSent, stats.sumBytesReceived))} name="Transferred" />
       <Statistic stat={'' + stats.count} name="Sessions" />

--- a/src/Pages/Authenticated/Settings/Components/Version.tsx
+++ b/src/Pages/Authenticated/Settings/Components/Version.tsx
@@ -7,8 +7,17 @@
 import React from 'react'
 import packageJson from '../../../../../package.json'
 
-const Version = () => {
-  return <div>WebUI version {packageJson.version}</div>
+interface Props {
+  nodeVersion?: string
+}
+
+const Version = ({ nodeVersion }: Props) => {
+  return (
+    <div>
+      <div>Node version {nodeVersion}</div>
+      <div>WebUI version {packageJson.version}</div>
+    </div>
+  )
 }
 
 export default Version

--- a/src/Pages/Authenticated/Settings/Settings.tsx
+++ b/src/Pages/Authenticated/Settings/Settings.tsx
@@ -30,6 +30,7 @@ import Version from './Components/Version'
 interface StateInterface {
   apiKey: string
   fees?: Fees
+  nodeVersion?: string
 }
 
 interface Props {
@@ -61,9 +62,9 @@ const Settings = ({ beneficiary, hermesId, identity, mmnWebAddress }: Props): JS
 
   const { enqueueSnackbar } = useSnackbar()
   useEffect(() => {
-    Promise.all([tequilapiClient.getMMNApiKey(), tequilapiClient.transactorFees()])
-      .then(([mmn, fees]) => {
-        setState({ ...state, apiKey: mmn.apiKey, fees: fees })
+    Promise.all([tequilapiClient.getMMNApiKey(), tequilapiClient.transactorFees(), tequilapiClient.healthCheck(15)])
+      .then(([mmn, fees, healthcheck]) => {
+        setState({ ...state, apiKey: mmn.apiKey, fees: fees, nodeVersion: healthcheck.version })
       })
       .catch((err) => {
         enqueueSnackbar(parseMMNError(err) || parseError(err), { variant: 'error' })
@@ -83,7 +84,7 @@ const Settings = ({ beneficiary, hermesId, identity, mmnWebAddress }: Props): JS
         <div className="main-block">
           <div className="settings-header">
             <Header logo={Logo} name="Settings" />
-            <Version />
+            <Version nodeVersion={state.nodeVersion} />
           </div>
           <div className="settings">
             <div className="settings__block">

--- a/src/Pages/Onboarding/OnboardingPage.tsx
+++ b/src/Pages/Onboarding/OnboardingPage.tsx
@@ -16,7 +16,7 @@ import Welcome from './steps/Welcome'
 import StepCounter from './StepCounter'
 import TermsAndConditions from './steps/TermsAndConditions'
 import PriceSettings from './steps/PriceSettings'
-import SettlementSettings from './steps/SettlementSettings'
+import PayoutSettings from './steps/PayoutSettings'
 
 import './Onboarding.scss'
 import { Onboarding } from '../../redux/app.slice'
@@ -55,9 +55,7 @@ const OnboardingPage = ({ onboarding, identity, config, fees }: Props) => {
 
   if (onboarding.needsRegisteredIdentity) {
     steps.push(<PriceSettings config={config} key="price" callbacks={callbacks} />)
-    steps.push(
-      <SettlementSettings key="payout" identity={identity} callbacks={callbacks} fees={fees} config={config} />,
-    )
+    steps.push(<PayoutSettings key="payout" identity={identity} callbacks={callbacks} fees={fees} config={config} />)
   }
 
   if (onboarding.needsPasswordChange) {

--- a/src/Pages/Onboarding/OnboardingPage.tsx
+++ b/src/Pages/Onboarding/OnboardingPage.tsx
@@ -53,8 +53,9 @@ const OnboardingPage = ({ onboarding, identity, config, fees }: Props) => {
     steps.push(<TermsAndConditions key="terms" callbacks={callbacks} />)
   }
 
+  steps.push(<PriceSettings config={config} key="price" callbacks={callbacks} />)
+
   if (onboarding.needsRegisteredIdentity) {
-    steps.push(<PriceSettings config={config} key="price" callbacks={callbacks} />)
     steps.push(<PayoutSettings key="payout" identity={identity} callbacks={callbacks} fees={fees} config={config} />)
   }
 

--- a/src/Pages/Onboarding/steps/PayoutSettings.tsx
+++ b/src/Pages/Onboarding/steps/PayoutSettings.tsx
@@ -41,7 +41,7 @@ interface StateInterface {
   chainId: number
 }
 
-const SettlementSettings = ({ callbacks, identity, config, fees }: Props) => {
+const PayoutSettings = ({ callbacks, identity, config, fees }: Props) => {
   const [state, setState] = useState<StateInterface>({
     beneficiary: '',
     stake: DEFAULT_STAKE_AMOUNT,
@@ -235,4 +235,4 @@ const SettlementSettings = ({ callbacks, identity, config, fees }: Props) => {
   )
 }
 
-export default SettlementSettings
+export default PayoutSettings


### PR DESCRIPTION
- Show `Total Earnings` in dashboard on test-net instead of `Unsettled Earnings`
- Include Node version in settings
- Automatically attempt a blunt login with default credentials
- Always show price step in onboarding