### PR TITLE
Empty MMN url bug + master rebase

### DIFF
--- a/src/Pages/Onboarding/steps/PasswordChange.tsx
+++ b/src/Pages/Onboarding/steps/PasswordChange.tsx
@@ -32,6 +32,7 @@ interface State {
   error: boolean
   errorMessage: string
   nodeClaimed: boolean
+  mmnDomain: string
 }
 
 interface Props {
@@ -49,9 +50,13 @@ const PasswordChange = ({ config }: Props): JSX.Element => {
     errorMessage: '',
     nodeClaimed: false,
     loading: false,
+    mmnDomain: '',
   })
 
   useEffect(() => {
+    setState((d) => {
+      d.mmnDomain = mmnDomainName(config)
+    })
     tequilapiClient.getMMNApiKey().then((resp) => {
       setState((d) => {
         d.apiKey = resp.apiKey
@@ -187,13 +192,13 @@ const MMNClaim = ({
   onApiKeyChange: (value: string) => void
   handleCheckboxChange: SwitchBaseProps['onChange']
 }) => {
-  return (
+  return state.mmnDomain !== 'error' ? (
     <>
       <div className="claim-row input-group m-t-50 m-b-20">
         <Checkbox
           checked={state.useApiKey}
           handleCheckboxChange={handleCheckboxChange}
-          label={'Claim this node in ' + mmnDomainName(config)}
+          label={'Claim this node in ' + state.mmnDomain}
         />
         <HelpTooltip
           title={
@@ -214,6 +219,8 @@ const MMNClaim = ({
         </div>
       ) : null}
     </>
+  ) : (
+    <></>
   )
 }
 

--- a/src/commons/config.ts
+++ b/src/commons/config.ts
@@ -7,6 +7,7 @@
 
 import _ from 'lodash'
 import { Config } from 'mysterium-vpn-js/lib/config/config'
+import { toastError } from './toast.utils'
 
 export const L1ChainId = 5
 export const L2ChainId = 80001
@@ -89,9 +90,13 @@ export const docsAddress = (c?: Config): string => {
 export const mmnDomainName = (c?: Config): string => {
   const address = _.get<Config, any>(c, 'data.mmn.web-address') || '#'
 
-  const url = new URL(address)
-
-  return url.hostname
+  try {
+    const url = new URL(address)
+    return url.hostname
+  } catch {
+    toastError('mmn url is not valid')
+    return 'error'
+  }
 }
 
 export const mmnApiKey = (c?: Config): string => {


### PR DESCRIPTION
Toast if shown on MMN URL error instead of crashing. MMN API key claim is hidden on error.

Closes: mysteriumnetwork/node#4161