### PR TITLE
Free registration fix

### DIFF
--- a/src/Pages/Onboarding/steps/Registration.tsx
+++ b/src/Pages/Onboarding/steps/Registration.tsx
@@ -56,13 +56,14 @@ const Registration = ({ nextStep }: StepProps) => {
   useEffect(() => {
     const init = async () => {
       try {
-        const [eligibility, summary] = await Promise.all([
+        const [eligibility, providerEligibility, summary] = await Promise.all([
           api.freeRegistrationEligibility(identity.id),
+          api.freeProviderRegistrationEligibility(),
           api.chainSummary(),
         ])
         setState((d) => {
           d.currentChainName = summary.chains[summary.currentChain]
-          d.isFreeRegistrationEligible = eligibility.eligible
+          d.isFreeRegistrationEligible = eligibility.eligible || providerEligibility.eligible
         })
       } catch (err) {
         toastError(parseError(err))

--- a/src/Pages/Onboarding/steps/TopUpModal.tsx
+++ b/src/Pages/Onboarding/steps/TopUpModal.tsx
@@ -85,6 +85,10 @@ const TopUpModal = ({ identity, onTopUp, open, onClose, isFreeRegistrationEligib
   const [isFree, setIsFree] = useState<boolean>(isFreeRegistrationEligible)
   const [isLoading, setIsLoading] = useState<boolean>(false)
 
+  useEffect(() => {
+    if (isFreeRegistrationEligible) setIsFree(isFreeRegistrationEligible)
+  }, [isFreeRegistrationEligible])
+
   const fees = useSelector(feesSelector)
 
   // use 2x registration fee for insurance
@@ -133,7 +137,7 @@ const TopUpModal = ({ identity, onTopUp, open, onClose, isFreeRegistrationEligib
                 { value: 'free', label: 'Register for free', disabled: !isFreeRegistrationEligible },
                 { value: 'paid', label: 'Deposit MYST token' },
               ]}
-              checked={isFreeRegistrationEligible ? 'free' : 'paid'}
+              checked={isFree ? 'free' : 'paid'}
               onChange={(value) => {
                 if (value === 'free') {
                   setIsFree(true)


### PR DESCRIPTION
This PR will not work without mysteriumnetwork/node#4425 and mysteriumnetwork/mysterium-vpn-js/#104 (and updating the npm package).

Issues solved:
- Free registration can be for 2 reasons: is a migration or daily limit is not reached, we were only checking the first one.
- The topup component is created when api calls are not yet resolved, so the checked value was not corresponding with isFree state one.

Also, the `freeRegistrationEligibility` call fails quite often, we should do something about it