### PR TITLE
General Improvements

### DIFF
--- a/src/Components/Table/Table.module.scss
+++ b/src/Components/Table/Table.module.scss
@@ -2,9 +2,26 @@
 @import '../../assets/styles/base/mixins/media';
 
 .table {
+  position: relative;
   width: 100%;
   display: flex;
   flex-direction: column;
+
+  &Spinner {
+    position: absolute;
+    z-index: 2;
+    left: 50%;
+    top: 50%;
+  }
+
+  &Overlay {
+    position: absolute;
+    z-index: 1;
+    width: 100%;
+    height: 100%;
+    background: #dfdfdfd1;
+    opacity: 50%;
+  }
 
   &Mobile {
     @include respond-above(sm) {

--- a/src/Components/Table/Table.tsx
+++ b/src/Components/Table/Table.tsx
@@ -97,7 +97,12 @@ const Table = ({
 
   return (
     <div className={styles.table}>
-      {loading && <CircularProgress className="spinner" disableShrink />}
+      {loading && (
+        <>
+          <div className={styles.tableOverlay} />
+          <CircularProgress className={styles.tableSpinner} disableShrink />
+        </>
+      )}
       <Media.Desktop>
         <div className={styles.tableDesktop}>
           <div>

--- a/src/Pages/AppRouter.tsx
+++ b/src/Pages/AppRouter.tsx
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import { CircularProgress } from '@material-ui/core'
 import { AppState } from 'mysterium-vpn-js'
 import React, { Dispatch, useEffect, useLayoutEffect } from 'react'
 import { Redirect, Route, Switch } from 'react-router-dom'
@@ -124,7 +123,7 @@ const AppRouter = ({ actions }: Props) => {
   }
 
   if (loading) {
-    return <CircularProgress className="spinner" disableShrink />
+    return <></>
   }
 
   return (

--- a/src/Pages/Authenticated/Components/Hotkeys/Hotkeys.tsx
+++ b/src/Pages/Authenticated/Components/Hotkeys/Hotkeys.tsx
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2021 BlockDev AG
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { useCallback, useEffect } from 'react'
+import { VERSION_MANAGEMENT } from '../../../../constants/routes'
+import { useHistory } from 'react-router-dom'
+
+interface Props {
+  children: JSX.Element
+}
+
+export const Hotkeys = ({ children }: Props) => {
+  const history = useHistory()
+
+  const handleKeyPress = useCallback((event) => {
+    if (event.key === 'F10' && history.location.pathname !== VERSION_MANAGEMENT) {
+      history.push(VERSION_MANAGEMENT)
+    }
+  }, [])
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleKeyPress)
+    return () => {
+      document.removeEventListener('keydown', handleKeyPress)
+    }
+  }, [handleKeyPress])
+
+  return <>{children}</>
+}

--- a/src/Pages/Authenticated/Components/Spinner/FullPageSpinner.tsx
+++ b/src/Pages/Authenticated/Components/Spinner/FullPageSpinner.tsx
@@ -9,7 +9,7 @@ import { CircularProgress } from '@material-ui/core'
 import React from 'react'
 import styles from './Spinner.module.scss'
 
-export const Spinner = () => {
+export const FullPageSpinner = () => {
   return (
     <>
       <div className={styles.overlay} />

--- a/src/Pages/Authenticated/Components/Spinner/Spinner.module.scss
+++ b/src/Pages/Authenticated/Components/Spinner/Spinner.module.scss
@@ -1,0 +1,18 @@
+.overlay {
+  width: 100%;
+  opacity: 50%;
+  z-index: 1000;
+  height: 100%;
+  background: #dfdfdfd1;
+  position: fixed;
+  top:        0;
+  left:       0;
+}
+
+.spinner {
+  top: calc(50% - 75px);
+  left: calc(50% - 75px);
+  position: absolute;
+  z-index: 1001;
+  position: fixed;
+}

--- a/src/Pages/Authenticated/Components/Spinner/Spinner.module.scss
+++ b/src/Pages/Authenticated/Components/Spinner/Spinner.module.scss
@@ -12,7 +12,6 @@
 .spinner {
   top: calc(50% - 75px);
   left: calc(50% - 75px);
-  position: absolute;
   z-index: 1001;
   position: fixed;
 }

--- a/src/Pages/Authenticated/Components/Spinner/Spinner.tsx
+++ b/src/Pages/Authenticated/Components/Spinner/Spinner.tsx
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2021 BlockDev AG
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { CircularProgress } from '@material-ui/core'
+import React from 'react'
+import styles from './Spinner.module.scss'
+
+export const Spinner = () => {
+  return (
+    <>
+      <div className={styles.overlay} />
+      <CircularProgress size={150} thickness={1} className={styles.spinner} disableShrink />
+    </>
+  )
+}

--- a/src/Pages/Authenticated/Dashboard/DashboardPage.tsx
+++ b/src/Pages/Authenticated/Dashboard/DashboardPage.tsx
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { CircularProgress } from '@material-ui/core'
 import { CurrentPricesResponse, Session, SessionDirection, SessionStats, SessionStatus } from 'mysterium-vpn-js'
 import React, { useEffect } from 'react'
 import { useSelector } from 'react-redux'
@@ -14,7 +13,7 @@ import { api } from '../../../api/Api'
 
 import { ReactComponent as Logo } from '../../../assets/images/authenticated/pages/dashboard/logo.svg'
 import { parseTequilApiError, UNKNOWN_API_ERROR } from '../../../commons/error.utils'
-import { isEmpty, isRegistered } from '../../../commons/identity.utils'
+import { isRegistered } from '../../../commons/identity.utils'
 import { toastError } from '../../../commons/toast.utils'
 import { AppState } from '../../../redux/app.slice'
 import { SSEState } from '../../../redux/sse.slice'
@@ -96,16 +95,13 @@ const DashboardPage = () => {
   }, [identity.id])
 
   const { appState } = sse
-  if (isEmpty(identity) || !appState || !config || state.loading) {
-    return <CircularProgress className="spinner" disableShrink />
-  }
-
   const { serviceInfo } = appState
 
   return (
     <Layout
       title="Dashboard"
       logo={<Logo />}
+      isLoading={state.loading}
       main={
         <>
           <CardLayout>

--- a/src/Pages/Authenticated/Layout.tsx
+++ b/src/Pages/Authenticated/Layout.tsx
@@ -9,7 +9,7 @@ import classNames from 'classnames'
 import Header from '../../Components/Header/Header'
 import React from 'react'
 import { media } from '../../commons/media.utils'
-import { Spinner } from './Components/Spinner/Spinner'
+import { FullPageSpinner } from './Components/Spinner/FullPageSpinner'
 
 interface Props {
   title?: string
@@ -30,7 +30,7 @@ export const Layout = ({ logo, title, main, showSideBar, sidebar, topRight, isLo
           <Header logo={logo} name={title} />
           {topRight}
         </div>
-        {isLoading && <Spinner />}
+        {isLoading && <FullPageSpinner />}
         {main}
       </div>
       {showSideBarAdjusted && <div className={styles.sidebarBlock}>{sidebar}</div>}

--- a/src/Pages/Authenticated/Layout.tsx
+++ b/src/Pages/Authenticated/Layout.tsx
@@ -9,7 +9,7 @@ import classNames from 'classnames'
 import Header from '../../Components/Header/Header'
 import React from 'react'
 import { media } from '../../commons/media.utils'
-import { CircularProgress } from '@material-ui/core'
+import { Spinner } from './Components/Spinner/Spinner'
 
 interface Props {
   title?: string
@@ -30,7 +30,8 @@ export const Layout = ({ logo, title, main, showSideBar, sidebar, topRight, isLo
           <Header logo={logo} name={title} />
           {topRight}
         </div>
-        {isLoading ? <CircularProgress className="spinner" disableShrink /> : main}
+        {isLoading && <Spinner />}
+        {main}
       </div>
       {showSideBarAdjusted && <div className={styles.sidebarBlock}>{sidebar}</div>}
     </main>

--- a/src/Pages/Authenticated/Sessions/SessionsPage.tsx
+++ b/src/Pages/Authenticated/Sessions/SessionsPage.tsx
@@ -70,7 +70,7 @@ const SessionsPage = ({ filterDirection = SessionDirection.PROVIDED }: Props) =>
   const liveSessions = useSelector<RootState, Session[] | undefined>(({ sse }) => sse.appState?.sessions)
   const liveSessionStats = useSelector<RootState, SessionStats | undefined>(({ sse }) => sse.appState?.sessionsStats)
 
-  const fetchData = React.useCallback(({ pageSize, pageIndex }) => {
+  const fetchData = React.useCallback(({ pageSize, page }) => {
     // Give this fetch an ID
     const fetchId = ++fetchIdRef.current
 
@@ -83,8 +83,8 @@ const SessionsPage = ({ filterDirection = SessionDirection.PROVIDED }: Props) =>
         .sessions({
           direction: filterDirection,
           providerId: filterProviderId,
-          pageSize: pageSize,
-          page: pageIndex,
+          pageSize,
+          page,
         })
         .then((resp) => {
           const { items = [], totalPages = 0 } = { ...resp }

--- a/src/Pages/Authenticated/Sessions/SessionsPage.tsx
+++ b/src/Pages/Authenticated/Sessions/SessionsPage.tsx
@@ -136,6 +136,7 @@ const SessionsPage = ({ filterDirection = SessionDirection.PROVIDED }: Props) =>
     <Layout
       title="Sessions"
       logo={<Logo />}
+      isLoading={state.isLoading}
       main={
         <Table
           columns={columns}

--- a/src/Pages/Authenticated/Settings/SettingsPage.tsx
+++ b/src/Pages/Authenticated/Settings/SettingsPage.tsx
@@ -44,7 +44,7 @@ interface StateInterface {
   apiKey: string
   nodeVersion?: string
   defaultConfig: Config
-  loading: boolean
+  isLoading: boolean
   nodeCommit?: string
 }
 
@@ -54,7 +54,7 @@ const SettingsPage = () => {
 
   const [state, setState] = React.useState<StateInterface>({
     apiKey: '',
-    loading: true,
+    isLoading: true,
     defaultConfig: { data: {} },
   })
 
@@ -65,7 +65,7 @@ const SettingsPage = () => {
           ...cs,
           apiKey: mmn.apiKey,
           nodeVersion: healthcheck.version,
-          loading: false,
+          isLoading: false,
           defaultConfig: defaultConfig,
           nodeCommit: healthcheck.buildInfo.commit,
         }))
@@ -73,7 +73,7 @@ const SettingsPage = () => {
       .catch((err) => toastError(parseError(err)))
   }, [identity?.id])
 
-  if (state.loading || !cfg) {
+  if (state.isLoading || !cfg) {
     return <CircularProgress className="spinner" disableShrink />
   }
 
@@ -84,6 +84,7 @@ const SettingsPage = () => {
       title="Settings"
       logo={<Logo />}
       topRight={<Version nodeVersion={state.nodeVersion} nodeCommit={state.nodeCommit} />}
+      isLoading={state.isLoading}
       main={
         <div className="settings">
           <div className="settings__block">

--- a/src/Pages/Authenticated/VersionManagement/VersionManagementPage.module.scss
+++ b/src/Pages/Authenticated/VersionManagement/VersionManagementPage.module.scss
@@ -22,6 +22,7 @@
   width: 100%;
   align-items: center;
   justify-content: center;
+  gap: 25px;
 }
 
 .infoCard {

--- a/src/Pages/Authenticated/VersionManagement/VersionManagementPage.module.scss
+++ b/src/Pages/Authenticated/VersionManagement/VersionManagementPage.module.scss
@@ -20,9 +20,18 @@
 .info {
   display: flex;
   width: 100%;
-  align-items: center;
+  height: 6rem;
   justify-content: center;
   gap: 25px;
+
+  .controls {
+    display: flex;
+    flex-direction: column;
+
+    gap: 10px;
+    height: 100%;
+    width: 10rem;
+  }
 }
 
 .infoCard {

--- a/src/Pages/Authenticated/VersionManagement/VersionManagementPage.module.scss
+++ b/src/Pages/Authenticated/VersionManagement/VersionManagementPage.module.scss
@@ -82,6 +82,15 @@
       display: flex;
     }
 
+    .releaseBlock {
+      margin-top: 8px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 5px;
+      width: 200px;
+    }
+
     .preRelease {
       font-size: $smaller-size;
       color: red;
@@ -101,4 +110,10 @@
       width: 120px;
     }
   }
+}
+
+.releaseNotes {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
 }

--- a/src/Pages/Authenticated/VersionManagement/VersionManagementPage.tsx
+++ b/src/Pages/Authenticated/VersionManagement/VersionManagementPage.tsx
@@ -77,13 +77,13 @@ export const VersionManagementPage = () => {
     return () => clearInterval(interval)
   }, [state.isDownloadInProgress])
 
-  const init = async () => {
+  const init = async (flushCache: boolean = false) => {
     try {
       setIsLoading()
       const [uiInfo, local, remote, dlStatus] = await Promise.all([
         info(),
         localVersions(),
-        remoteVersions(),
+        remoteVersions({ flushCache }),
         downloadStatus(),
       ])
       setState((d) => {
@@ -190,6 +190,11 @@ export const VersionManagementPage = () => {
                   <Button onClick={() => switchVersion('bundled')}>Switch Back</Button>
                 </div>
               )}
+            </div>
+            <div>
+              <Button onClick={() => init(true)} extraStyle="outline">
+                Flush Cache
+              </Button>
             </div>
           </div>
           <div className={styles.progress}>

--- a/src/Pages/Authenticated/VersionManagement/VersionManagementPage.tsx
+++ b/src/Pages/Authenticated/VersionManagement/VersionManagementPage.tsx
@@ -136,8 +136,8 @@ export const VersionManagementPage = () => {
   const notes = (notes: string): JSX.Element => {
     return (
       <div className={styles.releaseNotes}>
-        {notes.split('\r\n').map((it) => (
-          <p>{it}</p>
+        {notes.split('\r\n').map((it, index) => (
+          <p key={index}>{it}</p>
         ))}
       </div>
     )

--- a/src/Pages/Authenticated/VersionManagement/VersionManagementPage.tsx
+++ b/src/Pages/Authenticated/VersionManagement/VersionManagementPage.tsx
@@ -13,6 +13,7 @@ import styles from './VersionManagementPage.module.scss'
 import { date2human } from '../../../commons/date.utils'
 import Button from '../../../Components/Buttons/Button'
 import classNames from 'classnames'
+import HelpTooltip from '../../../Components/HelpTooltip/HelpTooltip'
 
 interface State {
   isLoading: boolean
@@ -132,6 +133,16 @@ export const VersionManagementPage = () => {
     }
   }
 
+  const notes = (notes: string): JSX.Element => {
+    return (
+      <div className={styles.releaseNotes}>
+        {notes.split('\r\n').map((it) => (
+          <p>{it}</p>
+        ))}
+      </div>
+    )
+  }
+
   const versionList = state.remote.versions
     .filter((rv) => rv.compatibilityUrl)
     .map((rv) => {
@@ -145,7 +156,10 @@ export const VersionManagementPage = () => {
               {rv.name === state.ui.bundledVersion && <div className={styles.preRelease}>(bundled)</div>}
               {rv.isPreRelease && <div className={styles.preRelease}>(pre-release)</div>}
             </div>
-            <div className={styles.released}>({date2human(rv.releasedAt)})</div>
+            <div className={styles.releaseBlock}>
+              <div className={styles.released}>({date2human(rv.releasedAt)})</div>
+              {rv.releaseNotes && <HelpTooltip title={notes(rv.releaseNotes)} />}
+            </div>
           </div>
           <div>
             {!local && (

--- a/src/Pages/Authenticated/VersionManagement/VersionManagementPage.tsx
+++ b/src/Pages/Authenticated/VersionManagement/VersionManagementPage.tsx
@@ -132,48 +132,46 @@ export const VersionManagementPage = () => {
     }
   }
 
-  const mmm = () => {
-    return state.remote.versions
-      .filter((rv) => rv.compatibilityUrl)
-      .map((rv) => {
-        const local = findLocal(rv.name)
+  const versionList = state.remote.versions
+    .filter((rv) => rv.compatibilityUrl)
+    .map((rv) => {
+      const local = findLocal(rv.name)
 
-        return (
-          <div key={rv.name} className={styles.row}>
-            <div>
-              <div className={styles.versionBlock}>
-                <div className={styles.name}>{rv.name}</div>
-                {rv.name === state.ui.bundledVersion && <div className={styles.preRelease}>(bundled)</div>}
-                {rv.isPreRelease && <div className={styles.preRelease}>(pre-release)</div>}
-              </div>
-              <div className={styles.released}>({date2human(rv.releasedAt)})</div>
+      return (
+        <div key={rv.name} className={styles.row}>
+          <div>
+            <div className={styles.versionBlock}>
+              <div className={styles.name}>{rv.name}</div>
+              {rv.name === state.ui.bundledVersion && <div className={styles.preRelease}>(bundled)</div>}
+              {rv.isPreRelease && <div className={styles.preRelease}>(pre-release)</div>}
             </div>
-            <div>
-              {!local && (
-                <Button
-                  className={styles.control}
-                  onClick={() => download(rv.name)}
-                  disabled={state.isDownloadInProgress}
-                  extraStyle="outline"
-                >
-                  Download
-                </Button>
-              )}
-              {local && !isInUse(local) && (
-                <Button
-                  className={styles.control}
-                  onClick={() => switchVersion(rv.name)}
-                  disabled={state.isDownloadInProgress}
-                  extraStyle="outline-primary"
-                >
-                  Switch
-                </Button>
-              )}
-            </div>
+            <div className={styles.released}>({date2human(rv.releasedAt)})</div>
           </div>
-        )
-      })
-  }
+          <div>
+            {!local && (
+              <Button
+                className={styles.control}
+                onClick={() => download(rv.name)}
+                disabled={state.isDownloadInProgress}
+                extraStyle="outline"
+              >
+                Download
+              </Button>
+            )}
+            {local && !isInUse(local) && (
+              <Button
+                className={styles.control}
+                onClick={() => switchVersion(rv.name)}
+                disabled={state.isDownloadInProgress}
+                extraStyle="outline-primary"
+              >
+                Switch
+              </Button>
+            )}
+          </div>
+        </div>
+      )
+    })
 
   return (
     <Layout
@@ -185,16 +183,14 @@ export const VersionManagementPage = () => {
             <div className={styles.infoCard}>
               {infoRow('Bundled:', state.ui.bundledVersion)}
               {infoRow('Used:', state.ui.usedVersion)}
-              {state.ui.usedVersion !== 'bundled' && (
-                <div className={styles.switchBack}>
-                  <Button onClick={() => switchVersion('bundled')}>Switch Back</Button>
-                </div>
-              )}
             </div>
-            <div>
+            <div className={styles.controls}>
               <Button onClick={() => init(true)} extraStyle="outline">
                 Flush Cache
               </Button>
+              {state.ui.usedVersion !== 'bundled' && (
+                <Button onClick={() => switchVersion('bundled')}>Switch Back</Button>
+              )}
             </div>
           </div>
           <div className={styles.progress}>
@@ -203,7 +199,7 @@ export const VersionManagementPage = () => {
               value={state.downloadProgress / 100}
             />
           </div>
-          <div className={styles.versions}>{mmm()}</div>
+          <div className={styles.versions}>{versionList}</div>
         </div>
       }
     />

--- a/src/Pages/Authenticated/Wallet/WalletPage.tsx
+++ b/src/Pages/Authenticated/Wallet/WalletPage.tsx
@@ -111,6 +111,7 @@ const WalletPage = () => {
     <Layout
       title="Wallet"
       logo={<Logo />}
+      isLoading={state.isLoading}
       main={
         <>
           <CardLayout>

--- a/src/api/NodeUIVersion.ts
+++ b/src/api/NodeUIVersion.ts
@@ -81,8 +81,9 @@ export interface LocalVersion {
 export interface RemoteVersion {
   name: string
   releasedAt: string
-  compatibilityUrl: string
+  compatibilityUrl?: string
   isPreRelease: boolean
+  releaseNotes?: string
 }
 
 export interface UI {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,6 +14,7 @@ import AppRouter from './Pages/AppRouter'
 import { store } from './redux/store'
 
 import { unregister } from './serviceWorker'
+import { Hotkeys } from './Pages/Authenticated/Components/Hotkeys/Hotkeys'
 
 ReactDOM.render(
   <Provider store={store}>
@@ -26,7 +27,9 @@ ReactDOM.render(
     >
       <SnackbarUtilsConfigurator />
       <HashRouter>
-        <AppRouter />
+        <Hotkeys>
+          <AppRouter />
+        </Hotkeys>
       </HashRouter>
     </SnackbarProvider>
   </Provider>,

--- a/src/redux/sse.slice.ts
+++ b/src/redux/sse.slice.ts
@@ -7,11 +7,44 @@
 import { createSlice } from '@reduxjs/toolkit'
 import { AppState } from 'mysterium-vpn-js'
 import _ from 'lodash'
+import { ConnectionStatus, NatStatus } from 'mysterium-vpn-js'
 
 export interface SSEState {
-  appState?: AppState
+  appState: AppState
 }
-const INITIAL_STATE: SSEState = {}
+
+const INITIAL_STATE: SSEState = {
+  appState: {
+    natStatus: {
+      status: NatStatus.NOT_FINISHED,
+    },
+    serviceInfo: [],
+    sessions: [],
+    sessionsStats: {
+      count: 0,
+      countConsumers: 0,
+      sumBytesReceived: 0,
+      sumBytesSent: 0,
+      sumDuration: 0,
+      sumTokens: 0,
+    },
+    consumer: {
+      connection: {
+        status: ConnectionStatus.NOT_CONNECTED,
+        statistics: {
+          bytesReceived: 0,
+          bytesSent: 0,
+          throughputSent: 0,
+          throughputReceived: 0,
+          duration: 0,
+          tokensSpent: 0,
+        },
+      },
+    },
+    identities: [],
+    channels: [],
+  },
+}
 
 const slice = createSlice({
   name: 'sse',


### PR DESCRIPTION
- Layout now has `isLoading` which will display a spinner with a transparent overlay for page content
- Table Spinner style fixed
- Pagination not working - fixes
- Version Managament can now be accessed by pressing `F10`
- Version Management list now has a release notes tooltip
- Version Management now has "flush cache" button that will refetch remote releases from github
- Version Management Page style facelift

![image](https://user-images.githubusercontent.com/20511486/147909751-e3a4d983-2011-4c32-bd35-8f6b4d33201d.png)
![image](https://user-images.githubusercontent.com/20511486/147909778-e50c00ac-18f5-49d3-b103-c7fb7b93a51d.png)
![image](https://user-images.githubusercontent.com/20511486/147909798-405160cf-ffaf-4fa9-b5cd-8e6130ee3bfc.png)
![image](https://user-images.githubusercontent.com/20511486/147909998-4c97a2e1-6b22-47f1-9acf-43cfed6ab438.png)
