### PR TITLE
Feedback changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "decimal.js": "^10.3.1",
     "immer": "^9.0.6",
     "lodash": "^4.17.21",
-    "mysterium-vpn-js": "18.7.0",
+    "mysterium-vpn-js": "18.9.0",
     "notistack": "1.0.10",
     "qs": "^6.10.2",
     "react": "17.0.2",

--- a/src/Pages/AppRouter.tsx
+++ b/src/Pages/AppRouter.tsx
@@ -43,6 +43,7 @@ import PageNotFound from './Error/PageNotFound'
 import AuthenticatedPage from './Authenticated/AuthenticatedPage'
 import { selectors } from '../redux/selectors'
 import OnBoardingPage from './Onboarding/OnBoardingPage'
+import { localStorageKeys } from '../constants/local_storage_keys'
 
 interface Props {
   actions: {
@@ -104,6 +105,16 @@ const AppRouter = ({ actions }: Props) => {
     // setInterval(() => actions.fetchFeesAsync(), 60_000)
   }
 
+  const loadIntercomCookie = () => {
+    const intercomUserId = localStorage.getItem(localStorageKeys.INTERCOM_USER_ID)
+    if (intercomUserId !== null && intercomUserId !== '') {
+      // @ts-ignore
+      window.Intercom('boot', {
+        anonymous_id: intercomUserId,
+      })
+    }
+  }
+
   useLayoutEffect(() => {
     const blockingCheck = async () => {
       let isDefaultPassword = await tequila.loginWithDefaultCredentials()
@@ -127,6 +138,8 @@ const AppRouter = ({ actions }: Props) => {
     if (!loggedIn) {
       return
     }
+
+    loadIntercomCookie()
 
     ConnectToSSE((state: AppState) => actions.sseAppStateStateChanged(state))
   }, [loggedIn])

--- a/src/constants/local_storage_keys.ts
+++ b/src/constants/local_storage_keys.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) 2021 BlockDev AG
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const INTERCOM_USER_ID = 'node-ui-intercom-user-id'
+
+export const localStorageKeys = {
+  INTERCOM_USER_ID,
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9285,10 +9285,10 @@ mute-stream@0.0.8:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
-mysterium-vpn-js@18.7.0:
-  version "18.7.0"
-  resolved "https://registry.yarnpkg.com/mysterium-vpn-js/-/mysterium-vpn-js-18.7.0.tgz#501b7aca5ce99f4f29369f40f3a1e4a01fb92b79"
-  integrity sha512-mOxQzQijklGZb0D/QBNH3rXM48vIQrKrdhhXCAwbbqV5TDxlIhRScoqJWNOIIfCurQASitLc2KR63TiWSAu2ug==
+mysterium-vpn-js@18.9.0:
+  version "18.9.0"
+  resolved "https://registry.yarnpkg.com/mysterium-vpn-js/-/mysterium-vpn-js-18.9.0.tgz#5052b0cccd6d23d2dfd8bbbbfe9bebe212aeabcd"
+  integrity sha512-6LXYgdQki08bd284gpAVgOu1dYUxIPaj7ZbdvpjxmssxWiPLqE+/qkJ9Vp96erR3fyyyVRmZ2pK8UIQxuSdKUw==
   dependencies:
     "@alloc/quick-lru" "^5.2.0"
     axios "^0.21.1"


### PR DESCRIPTION
Now feedback is sent using intercom and we do a best-effort try to open the newly created conversation (created from feedback service, not the ui itself).

Manual cookie persistence is needed because intercom cookies are not saved if accessing to the ip directly for some reason, in localhost it works fine.