### PR TITLE
automatically choose hermes in backend

### DIFF
--- a/src/Pages/Authenticated/Components/Card/EarningsCard/SettleSettingsModal.tsx
+++ b/src/Pages/Authenticated/Components/Card/EarningsCard/SettleSettingsModal.tsx
@@ -111,7 +111,7 @@ export const SettleSettingsModal = ({ open, onClose, onSave }: Props) => {
     try {
       await api.settleWithBeneficiary({
         providerId: identity.id,
-        hermesId: identity.hermesId,
+        hermesId: '',
         beneficiary: state.externalWalletAddress,
       })
       onSave()


### PR DESCRIPTION
node ui is unaware of which hermes has funds to settle so beneficiary call hermes id is now optional and backend will automatically settle with the one which has the most unsettled amount.

Signed-off-by: Guillem Bonet <guillem@mysterium.network>