### PR TITLE
Use history metrics to calculate series for dashboard chart

### DIFF
--- a/src/Pages/Authenticated/DashboardPage/Report/dates.ts
+++ b/src/Pages/Authenticated/DashboardPage/Report/dates.ts
@@ -5,14 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 export const localDate = (timestampSeconds: number): string => {
-  const date = new Date(timestampSeconds * 1000)
+  const date = new Date(timestampSeconds)
   const month = date.getMonth() + 1 < 10 ? `0${date.getMonth() + 1}` : date.getMonth() + 1
   const day = date.getDate() < 10 ? `0${date.getDate()}` : date.getDate()
   return `${month}-${day}`
 }
 
 export const hour = (timestampSeconds: number): string => {
-  const date = new Date(timestampSeconds * 1000)
+  const date = new Date(timestampSeconds)
   const hour = date.getHours() < 10 ? `0${date.getHours()}` : `${date.getHours()}`
   return `${hour}:00`
 }

--- a/src/Pages/Authenticated/DashboardPage/Report/series.test.ts
+++ b/src/Pages/Authenticated/DashboardPage/Report/series.test.ts
@@ -4,11 +4,12 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import series, { seriesToPairs } from './series'
+import series from './series'
 import { ChartType, Pair } from './types'
 import { currentCurrency } from '../../../../commons/currency'
-import { SeriesEntry } from 'mysterium-vpn-js'
 import { localDate } from './dates'
+import { SessionV2 } from 'mysterium-vpn-js'
+import { TOKENS_EMPTY } from '../../../../constants/instances'
 
 test.each<{ chart: ChartType; unit: any }>([
   { chart: 'data', unit: ' GiB' },
@@ -26,28 +27,49 @@ const nowMinusTwoDays = () => {
   return nowInSeconds() - 2 * 24 * 60 * 60
 }
 
-const twoDaysBefore = nowMinusTwoDays()
+const twoDaysBefore = new Date(nowMinusTwoDays())
+const twoDaysBeforeISO = new Date(nowMinusTwoDays()).toISOString()
+const twoDaysBeforePair = localDate(twoDaysBefore.getTime())
+
+const D: SessionV2 = {
+  id: '0',
+  consumerCountry: 'LT',
+  serviceType: 'wireguard',
+  durationSeconds: 120,
+  startedAt: new Date().toISOString(),
+  earnings: {
+    wei: '0',
+    ether: '1.00',
+    human: '1.00',
+  },
+  transferredBytes: 1_000_000,
+}
+
+const S = (or: Partial<SessionV2> = {}): SessionV2 => ({ ...D, ...or })
+
+const curried2Pairs = (type: ChartType, data: SessionV2 | SessionV2[]) =>
+  series._convert('7d', type, Array.isArray(data) ? data : [data])
 
 // 1663246040 === Thu Sep 15 2022 15:47:20 GMT+0300 (Eastern European Summer Time) {}
-test.each<{ entry: SeriesEntry; type: ChartType; expected: Pair }>([
+test.each<{ entry: SessionV2 | SessionV2[]; type: ChartType; expected: Pair }>([
   {
-    entry: { value: '130000000', timestamp: twoDaysBefore },
+    entry: S({ transferredBytes: 130000000, startedAt: twoDaysBeforeISO }),
     type: 'data',
-    expected: { x: localDate(twoDaysBefore), y: 0.12 },
+    expected: { x: twoDaysBeforePair, y: 0.12 },
   },
   {
-    entry: { value: '1000', timestamp: twoDaysBefore },
+    entry: S({ earnings: { ...TOKENS_EMPTY, human: '1000' }, startedAt: twoDaysBeforeISO }),
     type: 'earnings',
-    expected: { x: localDate(twoDaysBefore), y: 1000 },
+    expected: { x: twoDaysBeforePair, y: 1000 },
   },
   {
-    entry: { value: '2', timestamp: twoDaysBefore },
+    entry: [S({ startedAt: twoDaysBeforeISO }), S({ startedAt: twoDaysBeforeISO })],
     type: 'sessions',
-    expected: { x: localDate(twoDaysBefore), y: 2 },
+    expected: { x: twoDaysBeforePair, y: 2 },
   },
 ])('pair conversion %j', ({ entry, type, expected }) => {
   // given
-  const pairs = curried([entry], type)
+  const pairs = curried2Pairs(type, entry)
   const found = pairs.find((m) => m.y !== 0)
 
   // expect
@@ -55,5 +77,3 @@ test.each<{ entry: SeriesEntry; type: ChartType; expected: Pair }>([
   expect(found?.y).toEqual(expected.y)
   expect(found?.x).toEqual(expected.x)
 })
-
-const curried = (data: SeriesEntry[], type: ChartType) => seriesToPairs({ data }, '7d', type)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "lib": [
       "dom",
       "dom.iterable",


### PR DESCRIPTION
Drop usage of specialized series endpoints. Data between several endpoints tends to get into descrepancies.