### PR TITLE
Fetch node state only when user is authenticated

### DIFF
--- a/src/mobx/Indications.store.ts
+++ b/src/mobx/Indications.store.ts
@@ -17,6 +17,7 @@ export class IndicationsStore {
   status: string = 'pending'
   quality: number = 0
   loading: boolean = true
+  interval: ReturnType<typeof setInterval> | undefined = undefined
 
   constructor() {
     makeObservable(this, {
@@ -32,7 +33,9 @@ export class IndicationsStore {
   }
 
   setupReactions(): void {
-    setInterval(() => this.fetchState(), 60 * 1000)
+    if (!this.interval) {
+      this.interval = setInterval(() => this.fetchState(), 60 * 1000)
+    }
     this.fetchState()
   }
 

--- a/src/mobx/store.ts
+++ b/src/mobx/store.ts
@@ -22,7 +22,6 @@ export class MobXRootStore {
   constructor() {
     this.sessionsStore = new SessionsStore()
     this.indicationsStore = new IndicationsStore()
-    this.indicationsStore.setupReactions()
     this.beneficiaryStore = new BeneficiaryStore()
     this.clickBoardingStore = new ClickBoardingStore()
     this.menuStore = new MenuStore()

--- a/src/pages/StateInitializer.tsx
+++ b/src/pages/StateInitializer.tsx
@@ -14,6 +14,7 @@ import { selectors } from '../redux/selectors'
 import { tequila } from '../api/tequila'
 import ConnectToSSE from '../sse/server-sent-events'
 import listeners from '../redux/listeners'
+import { useStores } from '../mobx/store'
 import { IdentityRegistrationStatusListener } from './Authenticated/Components/Listeners/IdentityRegistrationStatusListener'
 
 interface Props {
@@ -21,6 +22,7 @@ interface Props {
 }
 
 export const StateInitializer = ({ children }: Props) => {
+  const { indicationsStore } = useStores()
   const dispatch = useAppDispatch()
   const actions = {
     updateLoadingStore: async (loading: boolean) => dispatch(updateLoadingStore(loading)),
@@ -56,6 +58,12 @@ export const StateInitializer = ({ children }: Props) => {
   }, [loggedIn])
 
   useEffect(() => {
+    listeners.registerAuthenticatedListener(({ payload }) => {
+      if (!payload.authenticated) {
+        return
+      }
+      indicationsStore.setupReactions()
+    })
     listeners.registerMinimumRegistrationAmountListener()
   }, [])
 

--- a/src/redux/listeners.ts
+++ b/src/redux/listeners.ts
@@ -8,7 +8,7 @@ import { myst } from '../commons/mysts'
 import { addListener, PayloadAction } from '@reduxjs/toolkit'
 import { FeesResponse } from 'mysterium-vpn-js'
 import { store } from './store'
-import { updateFeesStore, updateMinimumRegistrationAmountWeiStore } from './app.slice'
+import { updateAuthenticatedStore, updateFeesStore, updateMinimumRegistrationAmountWeiStore } from './app.slice'
 
 const FEE_SPIKE_MULTIPLIER = 1.5
 
@@ -26,7 +26,18 @@ const registerMinimumRegistrationAmountListener = () =>
     }),
   )
 
+const registerAuthenticatedListener = (
+  callback: (action: PayloadAction<{ authenticated: boolean }>) => Promise<void> | void,
+) =>
+  store.dispatch(
+    addListener({
+      actionCreator: updateAuthenticatedStore,
+      effect: callback,
+    }),
+  )
+
 const listeners = {
+  registerAuthenticatedListener,
   registerMinimumRegistrationAmountListener,
 }
 


### PR DESCRIPTION
this fix makes sure that we fetch the node status and quality values if user is authenticated
related issue: https://github.com/mysteriumnetwork/mystnodes/issues/320