### PR TITLE
Update DOCS_NAT_FIX URL for NAT types explanation

### DIFF
--- a/src/constants/urls.ts
+++ b/src/constants/urls.ts
@@ -6,7 +6,7 @@
  */
 
 export const DOCS = 'https://help.mystnodes.com'
-export const DOCS_NAT_FIX = `${DOCS}/en/articles/8205152-node-nat-statuses`
+export const DOCS_NAT_FIX = `${DOCS}/en/articles/8591945-nat-types-explained-and-how-to-fix-strict-nat`
 export const DOCS_FORGOT_PASSWORD = `${DOCS}/en/articles/8005248-forgot-password`
 export const DOCS_METAMASK = `${DOCS}/en/articles/8004186-adding-myst-token-to-metamask-on-the-polygon-mainnet`
 export const PAYOUT_GUIDE = `${DOCS}/en/articles/8004190-where-to-buy-polygon-myst`


### PR DESCRIPTION
The NAT help link currently points to an outdated article (8205152).

Updated it to the new documentation:
https://help.mystnodes.com/en/articles/8591945-nat-types-explained-and-how-to-fix-strict-nat

This ensures users are directed to the correct NAT explanation and troubleshooting guide.